### PR TITLE
Support CP437 on Windows

### DIFF
--- a/Sources/ZIP/ByteReader+Zip.swift
+++ b/Sources/ZIP/ByteReader+Zip.swift
@@ -21,8 +21,12 @@ extension LittleEndianByteReader {
             return String(data: stringData, encoding: .utf8)
         }
         if String.cp437Available && !stringData.needsUtf8() {
+        #if os(Windows)
+            return String(data: stringData, encoding: String.cp437Encoding)
+        #else
             return String(data: stringData, encoding: String.Encoding(rawValue:
                 CFStringConvertEncodingToNSStringEncoding(String.cp437Encoding)))
+        #endif
         } else {
             return String(data: stringData, encoding: .utf8)
         }
@@ -39,6 +43,10 @@ fileprivate extension String {
             static let cp437Encoding: CFStringEncoding = UInt32(truncatingIfNeeded: UInt(kCFStringEncodingDOSLatinUS))
         #endif
         static let cp437Available: Bool = CFStringIsEncodingAvailable(cp437Encoding)
+    #elseif os(Windows)
+        // "Latin-US (DOS)" CP437-2147483120
+        static let cp437Encoding = String.Encoding(rawValue: 0x80000400)
+        static let cp437Available = String.availableStringEncodings.contains(cp437Encoding)
     #else
         static let cp437Encoding = CFStringEncoding(CFStringEncodings.dosLatinUS.rawValue)
         static let cp437Available = CFStringIsEncodingAvailable(cp437Encoding)


### PR DESCRIPTION
Simple patch to add CP437 support on Windows now that Swift 5.4 has official SPM support and CoreFoundation won't be shipped with Windows releases by the looks of it. This is the only change required to compile this library on Windows.

Thanks for this excellent library!

Side Note:

There's already bug reports in for issues with the compiler in Swift 5.4, but it seems to have an issue with the 7-Zip module. I dug into it but I have no idea why, I've simply commented out 7-Zip in the sources in the package for my own use in the mean time (but not in this patch of course).