### PR TITLE
[swcomp] Use `autoreleasepool` to immediately free memory when untarring file with rw-api

### DIFF
--- a/Sources/swcomp/Containers/TarCommand.swift
+++ b/Sources/swcomp/Containers/TarCommand.swift
@@ -180,13 +180,17 @@ class TarCommand: Command {
             let fileManager = FileManager.default
             let outputURL = URL(fileURLWithPath: outputPath)
             var directoryAttributes = [(attributes: [FileAttributeKey: Any], path: String)]()
-            while true {
-                guard let entry = try reader.next()
-                    else { break }
-                if entry.info.type == .directory {
-                    directoryAttributes.append(try writeDirectory(entry, outputURL, verbose))
-                } else {
-                    try writeFile(entry, outputURL, verbose)
+            var hasData = true
+            while hasData {
+                hasData = try autoreleasepool {
+                    guard let entry = try reader.next()
+                    else { return false }
+                    if entry.info.type == .directory {
+                        directoryAttributes.append(try writeDirectory(entry, outputURL, verbose))
+                    } else {
+                        try writeFile(entry, outputURL, verbose)
+                    }
+                    return true
                 }
             }
             try handle.closeHandleCompat()


### PR DESCRIPTION
This relates to [this issue](https://github.com/tsolomko/SWCompression/issues/28).

Using `FileHandle` to read contents of tarfile does avoid reading entire file into memory. However, without `autoreleasepool`, the data buffers are not released fast enough to avoid a temporary (potentially large) increase in memory usage. 

Cf. [Use Local Autorelease Pool Blocks to Reduce Peak Memory Footprint](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmAutoreleasePools.html)