### PR TITLE
[TAR] Init a TarEntry with a fileURL + InputStream

### DIFF
--- a/Sources/TAR/TarContainer.swift
+++ b/Sources/TAR/TarContainer.swift
@@ -79,8 +79,8 @@ public class TarContainer: Container {
      - SeeAlso: `TarEntryInfo` properties documenation to see how their values are connected with the specific TAR
      format used during container creation.
      */
-    public static func create(from entries: [TarEntry]) -> Data {
-        return create(from: entries, force: .pax)
+    public static func create(from entries: [TarEntry]) throws -> Data {
+        return try create(from: entries, force: .pax)
     }
 
     /**
@@ -100,7 +100,7 @@ public class TarContainer: Container {
      - SeeAlso: `TarEntryInfo` properties documenation to see how their values are connected with the specific TAR
      format used during container creation.
      */
-    public static func create(from entries: [TarEntry], force format: TarContainer.Format) -> Data {
+    public static func create(from entries: [TarEntry], force format: TarContainer.Format) throws -> Data {
         // The general strategy is as follows. For each entry we:
         //  1. Create special entries if required by the entry's info and if supported by the format.
         //  2. For each special entry we create a TarHeader.
@@ -166,6 +166,9 @@ public class TarContainer: Container {
             if let data = entry.data {
                 out.appendAsTarBlock(data)
             }
+			else if let file = entry.file {
+				try out.appendAsTarBlock(file)
+			}
         }
         // Two 512-byte blocks consisting of zeros as an EOF marker.
         out.append(Data(count: 1024))

--- a/Sources/TAR/TarEntry.swift
+++ b/Sources/TAR/TarEntry.swift
@@ -11,7 +11,7 @@ public struct TarEntry: ContainerEntry {
     public var info: TarEntryInfo
 
     /**
-     Entry's data (`nil` if entry is a directory or data isn't available).
+     Entry's data (`nil` if entry is a directory, data isn't available or is set as the file URL).
 
      - Note: Accessing setter of this property causes `info.size` to be updated as well so it remains equal to
      `data.count`. If `data` is set to be `nil` then `info.size` is set to zero.
@@ -21,6 +21,11 @@ public struct TarEntry: ContainerEntry {
             self.info.size = self.data?.count ?? 0
         }
     }
+	
+	/**
+	 Entry's URL (`nil` by default and only used if `data` is `nil`).
+	 */
+	public var file: URL?
 
     /**
      Initializes the entry with its info and data. The stored `info.size` will also be updated to be equal to
@@ -34,5 +39,16 @@ public struct TarEntry: ContainerEntry {
         self.info.size = data?.count ?? 0
         self.data = data
     }
+	
+	/**
+	 Initializes the entry with its info and file URL.  If `data` is `nil` then  we will check for `file`.
+
+	 - Parameter info: Information about entry.
+	 - Parameter file: Entry's URL, `nil` if set in data Data.
+	 */
+	public init(info: TarEntryInfo, file: URL?) {
+		self.info = info
+		self.file = file
+	}
 
 }


### PR DESCRIPTION
Added the ability to initialize a TarEntry using a fileURL in conjunction with and InputStream.

This is an alternative as having to pass all the file's data. This enables to process large files without reading the whole file on memory first, since it then gets read in blocks of 1024 bytes.