### PR TITLE
Swift 6, Codable, Sendable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:6.0
 import PackageDescription
 
 var package = Package(
@@ -17,7 +17,7 @@ var package = Package(
             targets: ["SWCompression"]),
     ],
     dependencies: [
-        .package(name: "BitByteData", url: "https://github.com/tsolomko/BitByteData",
+        .package(url: "https://github.com/tsolomko/BitByteData",
                  from: "2.0.0"),
     ],
     targets: [
@@ -29,11 +29,11 @@ var package = Package(
             sources: ["Common", "7-Zip", "BZip2", "Deflate", "GZip", "LZ4", "LZMA", "LZMA2", "TAR", "XZ", "ZIP", "Zlib"],
             resources: [.copy("PrivacyInfo.xcprivacy")]),
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v5, .v6]
 )
 
 #if os(macOS)
-package.dependencies.append(.package(name: "SwiftCLI", url: "https://github.com/jakeheis/SwiftCLI", from: "6.0.0"))
+package.dependencies.append(.package(url: "https://github.com/jakeheis/SwiftCLI", from: "6.0.0"))
 package.targets.append(.executableTarget(name: "swcomp", dependencies: ["SWCompression", "SwiftCLI"], path: "Sources",
             exclude: ["Common", "7-Zip", "BZip2", "Deflate", "GZip", "LZ4", "LZMA", "LZMA2", "TAR", "XZ", "ZIP", "Zlib", "PrivacyInfo.xcprivacy"],
             sources: ["swcomp"]))

--- a/Sources/7-Zip/7zEntryInfo.swift
+++ b/Sources/7-Zip/7zEntryInfo.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Provides access to information about an entry from the 7-Zip container.
-public struct SevenZipEntryInfo: ContainerEntryInfo {
+public struct SevenZipEntryInfo: ContainerEntryInfo, Codable, Sendable {
 
     // MARK: ContainerEntryInfo
 

--- a/Sources/Common/CompressionMethod.swift
+++ b/Sources/Common/CompressionMethod.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Represents a (de)compression method.
-public enum CompressionMethod {
+public enum CompressionMethod: Codable, Sendable {
     /// BZip2.
     case bzip2
     /// Copy (no compression).

--- a/Sources/Common/Container/ContainerEntry.swift
+++ b/Sources/Common/Container/ContainerEntry.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// A type that represents an entry from the container with its data and information.
-public protocol ContainerEntry {
+public protocol ContainerEntry: Codable, Sendable {
 
     /// A type that provides information about an entry.
     associatedtype Info: ContainerEntryInfo

--- a/Sources/Common/Container/ContainerEntryType.swift
+++ b/Sources/Common/Container/ContainerEntryType.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Represents the type of a container entry.
-public enum ContainerEntryType {
+public enum ContainerEntryType: Codable, Sendable {
     /// Block special file.
     case blockSpecial
     /// Character special file.

--- a/Sources/Common/Container/DosAttributes.swift
+++ b/Sources/Common/Container/DosAttributes.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Represents file attributes in DOS format.
-public struct DosAttributes: OptionSet {
+public struct DosAttributes: OptionSet, Codable, Sendable {
 
     /// Raw bit flags value.
     public let rawValue: UInt32

--- a/Sources/Common/Container/Permissions.swift
+++ b/Sources/Common/Container/Permissions.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Represents file access permissions in UNIX format.
-public struct Permissions: OptionSet {
+public struct Permissions: OptionSet, Codable, Sendable {
 
     /// Raw bit flags value (in decimal).
     public let rawValue: UInt32

--- a/Sources/Common/FileSystemType.swift
+++ b/Sources/Common/FileSystemType.swift
@@ -9,7 +9,7 @@ import Foundation
  Represents the type of the file system on which an archive or container was created. File system determines the meaning
  of file attributes.
  */
-public enum FileSystemType {
+public enum FileSystemType: Codable, Sendable {
     /// FAT filesystem.
     case fat
     /// Filesystem of older Macintosh systems.

--- a/Sources/GZip/GzipArchive.swift
+++ b/Sources/GZip/GzipArchive.swift
@@ -7,10 +7,10 @@ import Foundation
 import BitByteData
 
 /// Provides unarchive and archive functions for GZip archives.
-public class GzipArchive: Archive {
+public final class GzipArchive: Archive, Codable, Sendable {
 
     /// Represents the member of a multi-member GZip archive.
-    public struct Member {
+    public struct Member: Codable, Sendable {
 
         /// GZip header of a member.
         public let header: GzipHeader

--- a/Sources/GZip/GzipHeader+ExtraField.swift
+++ b/Sources/GZip/GzipHeader+ExtraField.swift
@@ -6,7 +6,7 @@
 extension GzipHeader {
 
     /// Represents an extra field in the header of a GZip archive.
-    public struct ExtraField {
+    public struct ExtraField: Codable, Sendable {
 
         /// First byte of the extra field (subfield) ID.
         public let si1: UInt8

--- a/Sources/GZip/GzipHeader.swift
+++ b/Sources/GZip/GzipHeader.swift
@@ -7,7 +7,7 @@ import Foundation
 import BitByteData
 
 /// Represents the header of a GZip archive.
-public struct GzipHeader {
+public struct GzipHeader: Codable, Sendable {
 
     struct Flags: OptionSet {
         let rawValue: UInt8

--- a/Sources/TAR/TarEntryInfo.swift
+++ b/Sources/TAR/TarEntryInfo.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Provides access to information about an entry from the TAR container.
-public struct TarEntryInfo: ContainerEntryInfo {
+public struct TarEntryInfo: ContainerEntryInfo, Codable, Sendable {
 
     // MARK: ContainerEntryInfo
 
@@ -70,7 +70,7 @@ public struct TarEntryInfo: ContainerEntryInfo {
     // MARK: TAR specific
 
     /// Entry's compression method. Always `.copy` for the entries of TAR containers.
-    public let compressionMethod = CompressionMethod.copy
+    public var compressionMethod: CompressionMethod { CompressionMethod.copy }
 
     /**
      ID of entry's owner.

--- a/Sources/ZIP/ZipContainer.swift
+++ b/Sources/ZIP/ZipContainer.swift
@@ -7,7 +7,7 @@ import Foundation
 import BitByteData
 
 /// Provides functions for work with ZIP containers.
-public class ZipContainer: Container {
+public final class ZipContainer: Container, Codable, Sendable {
 
     /**
      Contains user-defined extra fields. When either `ZipContainer.info(container:)` or `ZipContainer.open(container:)`
@@ -22,7 +22,7 @@ public class ZipContainer: Container {
      - Warning: Modifying this dictionary while either `info(container:)` or `open(container:)` function is being
      executed may cause undefined behavior.
      */
-    public static var customExtraFields = [UInt16: ZipExtraField.Type]()
+    public static let customExtraFields = [UInt16: ZipExtraField.Type]()
 
     /**
      Processes ZIP container and returns an array of `ZipEntry` with information and data for all entries.

--- a/Sources/ZIP/ZipEntry.swift
+++ b/Sources/ZIP/ZipEntry.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Represents an entry from the ZIP container.
-public struct ZipEntry: ContainerEntry {
+public struct ZipEntry: ContainerEntry, Codable, Sendable {
 
     public let info: ZipEntryInfo
 

--- a/Sources/ZIP/ZipExtraField.swift
+++ b/Sources/ZIP/ZipExtraField.swift
@@ -6,7 +6,7 @@
 import BitByteData
 
 /// A type that represents an extra field from a ZIP container.
-public protocol ZipExtraField {
+public protocol ZipExtraField: Codable, Sendable {
 
     /**
      ID of extra field. Must be equal to the key of extra field in `ZipContainer.customExtraFields` dictionary and
@@ -50,7 +50,7 @@ extension ZipExtraField {
 }
 
 /// Location of ZIP extra field inside a container.
-public enum ZipExtraFieldLocation {
+public enum ZipExtraFieldLocation: Codable, Sendable {
     /// ZIP extra field is located in container's Central Directory.
     case centralDirectory
     /// ZIP extra field is located in one of container's Local Headers.

--- a/Sources/swcomp/Benchmarks/BenchmarkResult.swift
+++ b/Sources/swcomp/Benchmarks/BenchmarkResult.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct BenchmarkResult: Codable {
+struct BenchmarkResult: Codable, Sendable {
 
     var name: String
     var input: String

--- a/Sources/swcomp/Benchmarks/SaveFile.swift
+++ b/Sources/swcomp/Benchmarks/SaveFile.swift
@@ -5,17 +5,15 @@
 
 import Foundation
 
-struct SaveFile: Codable {
+struct SaveFile: Codable, Sendable {
 
-    struct Run: Codable {
+    struct Run: Codable, Sendable {
 
         var metadataUUID: UUID
         var results: [BenchmarkResult]
 
     }
-
     var metadatas: [UUID: BenchmarkMetadata]
-
     var runs: [Run]
 
     static func load(from path: String) throws -> SaveFile {


### PR DESCRIPTION
Add Swift 6 support, plus sendable and codable to most datatypes.

Changes:

- All Packages builds on iOS now by #if'def'ing out `Process` which is not available on iOS
- Added Swift 6 and 6.0 SPM values to `Package.swift`
- Added automatic codable and sendable conformance
- Manually added Codable support for `ZipEntryInfo` with the caveat that `[ZipExtraField]` is skipped over.

Issues:

ZipExtraField protocol not encodable. Either a need concrete types, another workaround or a way to regenerate.